### PR TITLE
Fixes two issues when multiple notifications were available while app is backgrounded.

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/core/NotificationIntentAdapter.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/NotificationIntentAdapter.java
@@ -13,6 +13,9 @@ public class NotificationIntentAdapter {
 
     public static PendingIntent createPendingNotificationIntent(Context appContext, Intent intent, PushNotificationProps notification) {
         intent.putExtra(PUSH_NOTIFICATION_EXTRA_NAME, notification.asBundle());
+        // a unique action, data, type, class, or category must be set, otherwise the intent matcher
+        // gets confused see https://developer.android.com/reference/android/app/PendingIntent
+        intent.setAction(String.valueOf(System.currentTimeMillis()));
         return PendingIntent.getService(appContext, PENDING_INTENT_CODE, intent, PendingIntent.FLAG_ONE_SHOT);
     }
 

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -84,7 +84,6 @@ public class PushNotification implements IPushNotification {
     @Override
     public void onOpened() {
         digestNotification();
-        clearAllNotifications();
     }
 
     @Override

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawer.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawer.java
@@ -32,12 +32,16 @@ public class PushNotificationsDrawer implements IPushNotificationsDrawer {
 
     @Override
     public void onAppInit() {
-        clearAll();
+        /**
+         * No OP.
+         */
     }
 
     @Override
     public void onAppVisible() {
-        clearAll();
+        /**
+         * No OP.
+         */
     }
 
     @Override
@@ -51,7 +55,9 @@ public class PushNotificationsDrawer implements IPushNotificationsDrawer {
 
     @Override
     public void onNotificationOpened() {
-        clearAll();
+        /**
+         * No OP.
+         */
     }
 
     @Override


### PR DESCRIPTION
1)  When multiple notifications were stacked and one was picked all remaining notifications would be cleared.
2)  When multiple notifications were stacked and one was clicked, the wrong notification deep link route would be used.

This resolves the first by no longer clearing all notifications when one is clicked, and resolves the second by uniquely identifying the pending intents we leverage for our notifications to allow the intent matcher to properly match the correct intent.