### PR TITLE
add RNNotificationsNativeCallback so native can track PN events that weren't sent to JS

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -30,11 +30,11 @@ import static com.wix.reactnativenotifications.Defs.LOGTAG;
 
 public class RNNotificationsModule extends ReactContextBaseJavaModule implements AppLifecycleFacade.AppVisibilityListener, Application.ActivityLifecycleCallbacks {
 
-    public RNNotificationsModule(Application application, ReactApplicationContext reactContext) {
+    public RNNotificationsModule(Application application, RNNotificationsNativeCallback nativeCallback, ReactApplicationContext reactContext) {
         super(reactContext);
 
         if (AppLifecycleFacadeHolder.get() instanceof ReactAppLifecycleFacade) {
-            ((ReactAppLifecycleFacade) AppLifecycleFacadeHolder.get()).init(reactContext);
+            ((ReactAppLifecycleFacade) AppLifecycleFacadeHolder.get()).init(reactContext, nativeCallback);
         }
         AppLifecycleFacadeHolder.get().addVisibilityListener(this);
         application.registerActivityLifecycleCallbacks(this);

--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsNativeCallback.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsNativeCallback.java
@@ -1,0 +1,7 @@
+package com.wix.reactnativenotifications;
+
+import com.facebook.react.bridge.WritableMap;
+
+public interface RNNotificationsNativeCallback {
+    void onEventNotSentToJS(String eventName, WritableMap data);
+}

--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
@@ -14,14 +14,19 @@ import java.util.List;
 public class RNNotificationsPackage implements ReactPackage {
 
     private final Application mApplication;
+    private RNNotificationsNativeCallback mNativeCallback;
 
     public RNNotificationsPackage(Application application) {
         mApplication = application;
     }
 
+    public void addNativeCallback(RNNotificationsNativeCallback rnNotificationsNativeCallback) {
+        mNativeCallback = rnNotificationsNativeCallback;
+    }
+
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        return Arrays.<NativeModule>asList(new RNNotificationsModule(mApplication, reactContext));
+        return Arrays.<NativeModule>asList(new RNNotificationsModule(mApplication, mNativeCallback, reactContext));
     }
 
     @Override

--- a/android/src/main/java/com/wix/reactnativenotifications/core/AppLifecycleFacade.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/AppLifecycleFacade.java
@@ -1,5 +1,6 @@
 package com.wix.reactnativenotifications.core;
 
+import com.wix.reactnativenotifications.RNNotificationsNativeCallback;
 import com.facebook.react.bridge.ReactContext;
 
 public interface AppLifecycleFacade {
@@ -11,6 +12,7 @@ public interface AppLifecycleFacade {
 
     boolean isReactInitialized();
     ReactContext getRunningReactContext();
+    RNNotificationsNativeCallback getNativeCallback();
     boolean isAppVisible();
     void addVisibilityListener(AppVisibilityListener listener);
     void removeVisibilityListener(AppVisibilityListener listener);

--- a/android/src/main/java/com/wix/reactnativenotifications/core/JsIOHelper.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/JsIOHelper.java
@@ -1,5 +1,6 @@
 package com.wix.reactnativenotifications.core;
 
+import com.wix.reactnativenotifications.RNNotificationsNativeCallback;
 import android.os.Bundle;
 
 import com.facebook.react.bridge.Arguments;
@@ -8,18 +9,18 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 public class JsIOHelper {
-    public boolean sendEventToJS(String eventName, Bundle data, ReactContext reactContext) {
-        if (reactContext != null) {
-            sendEventToJS(eventName, Arguments.fromBundle(data), reactContext);
-            return true;
-        }
-        return false;
+    public boolean sendEventToJS(String eventName, Bundle data, AppLifecycleFacade appLifecycleFacade) {
+        return sendEventToJS(eventName, Arguments.fromBundle(data), appLifecycleFacade);
     }
 
-    public boolean sendEventToJS(String eventName, WritableMap data, ReactContext reactContext) {
-        if (reactContext != null) {
+    public boolean sendEventToJS(String eventName, WritableMap data, AppLifecycleFacade appLifecycleFacade) {
+        RNNotificationsNativeCallback nativeCallback = appLifecycleFacade.getNativeCallback();
+        ReactContext reactContext = appLifecycleFacade.getRunningReactContext();
+        if (appLifecycleFacade.isReactInitialized() && reactContext != null) {
             reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName, data);
             return true;
+        } else if (nativeCallback != null) {
+            nativeCallback.onEventNotSentToJS(eventName, data);
         }
         return false;
     }

--- a/android/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
@@ -1,5 +1,6 @@
 package com.wix.reactnativenotifications.core;
 
+import com.wix.reactnativenotifications.RNNotificationsNativeCallback;
 import android.util.Log;
 
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -14,10 +15,12 @@ public class ReactAppLifecycleFacade implements AppLifecycleFacade {
 
     private ReactContext mReactContext;
     private boolean mIsVisible;
+    private RNNotificationsNativeCallback mNativeCallback;
     private Set<AppVisibilityListener> mListeners = new CopyOnWriteArraySet<>();
 
-    public void init(ReactContext reactContext) {
+    public void init(ReactContext reactContext, RNNotificationsNativeCallback nativeCallback) {
         mReactContext = reactContext;
+        mNativeCallback = nativeCallback;
         reactContext.addLifecycleEventListener(new LifecycleEventListener() {
             @Override
             public void onHostResume() {
@@ -56,6 +59,11 @@ public class ReactAppLifecycleFacade implements AppLifecycleFacade {
         }
 
         return mReactContext;
+    }
+
+    @Override
+    public RNNotificationsNativeCallback getNativeCallback() {
+        return mNativeCallback;
     }
 
     @Override

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -307,15 +307,15 @@ public class PushNotification implements IPushNotification {
     }
 
     private void notifyReceivedToJS() {
-        mJsIOHelper.sendEventToJS(NOTIFICATION_RECEIVED_EVENT_NAME, mNotificationProps.asBundle(), mAppLifecycleFacade.getRunningReactContext());
+        mJsIOHelper.sendEventToJS(NOTIFICATION_RECEIVED_EVENT_NAME, mNotificationProps.asBundle(), mAppLifecycleFacade);
     }
 
     private void notifiyReceivedForegroundNotificationToJS() {
-        mJsIOHelper.sendEventToJS(NOTIFICATION_RECEIVED_FOREGROUND_EVENT_NAME, mNotificationProps.asBundle(), mAppLifecycleFacade.getRunningReactContext());
+        mJsIOHelper.sendEventToJS(NOTIFICATION_RECEIVED_FOREGROUND_EVENT_NAME, mNotificationProps.asBundle(), mAppLifecycleFacade);
     }
 
     private void notifyOpenedToJS() {
-        mJsIOHelper.sendEventToJS(NOTIFICATION_OPENED_EVENT_NAME, mNotificationProps.asBundle(), mAppLifecycleFacade.getRunningReactContext());
+        mJsIOHelper.sendEventToJS(NOTIFICATION_OPENED_EVENT_NAME, mNotificationProps.asBundle(), mAppLifecycleFacade);
     }
 
     protected void launchOrResumeApp() {

--- a/android/src/main/java/com/wix/reactnativenotifications/gcm/FcmInstanceIdListenerService.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/gcm/FcmInstanceIdListenerService.java
@@ -98,6 +98,7 @@ public class FcmInstanceIdListenerService extends FirebaseMessagingService {
         } catch (IPushNotification.InvalidNotificationException e) {
             // A GCM message, yes - but not the kind we know how to work with.
             Log.v(LOGTAG, "GCM message handling aborted", e);
+            FLog.i(LOG_TAG, "GCM message handling aborted: " + bundle);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-notifications",
-  "version": "1.2.0-convoyv3",
+  "version": "1.2.0-convoyv4",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
* We'd like to be able to track push notification events that were received natively on Android, but were not delivered to JS. This allows us to track metrics on received push notifications.
* Added `RNNotificationsNativeCallback` with an `onEventNotSentToJS()` method
* Allow the application to call `addNativeCallback()` on the `RNNotificationsPackage`, which will be retained on the `RNNotificationsModule` each time one is instantiated, and will be in turn retained on the singleton `ReactAppLifecycleFacade` as its `init()` method is called for each new `RNNotificationsModule`
* Change `sendEventToJS()` to check `isReactInitialized()` before assuming that the `reactContext` is still valid (bug fix: avoids `ReactNative: Calling JS function after bridge has been destroyed` messages)
* Call the new `onEventNotSentToJS()` native callback when registered if the event could not be sent to the JavaScript side