### PR TITLE
Say when! -- Show Notification Time

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -211,6 +211,7 @@ public class PushNotification implements IPushNotification {
             .setContentIntent(intent)
             .setVibrate(mNotificationProps.getVibrationPattern())
             .setSmallIcon(smallIconResId)
+            .setShowWhen(true)
             .setAutoCancel(true);
 
         int badge = mNotificationProps.getBadge();


### PR DESCRIPTION
Show timestamp for Convoy Push Notifications

![image](https://user-images.githubusercontent.com/645300/61328682-6de0dc80-a7d0-11e9-88d1-ef18611d9f4e.png)

^^^ The docs for "3" says:

> Timestamp: This is provided by the system but you can override with setWhen() or hide it with 
setShowWhen(false).

> For apps targeting Build.VERSION_CODES.N and above, this time is not shown anymore by default and must be opted into by using setShowWhen(boolean)

Also: `setShowWhen` has an API level of 17 above [[link](https://developer.android.com/reference/android/app/Notification.Builder.html#setShowWhen(boolean))], and our minsdk is 21, so it's safe for us to always use.

### Before
Notice: the "You have a new offer" does not have a timestamp:
<img width="527" alt="Screen Shot 2019-07-16 at 1 43 20 PM" src="https://user-images.githubusercontent.com/645300/61328803-aed8f100-a7d0-11e9-97ca-80ae21231409.png">


### After
Notice: the "You have a new offer" has a new timestamp:
<img width="527" alt="Screen Shot 2019-07-16 at 1 44 50 PM" src="https://user-images.githubusercontent.com/645300/61328850-c87a3880-a7d0-11e9-8496-93e286f79c31.png">

And some time later:
<img width="527" alt="Screen Shot 2019-07-16 at 1 48 57 PM" src="https://user-images.githubusercontent.com/645300/61328851-c87a3880-a7d0-11e9-92a0-dd508cafa27a.png">
