### PR TITLE
Updates FcmToken.sendTokenToJS to always post a runnable to the UI thread.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-notifications",
-  "version": "1.2.0-convoyv7",
+  "version": "1.2.0-convoyv8",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This is required due to the changes around JobIntentService required for scheduling
work on android O and above.  In this mode the FcmToken methods can be executed
on threads other than the UI thread.  This flow can cause the main ReactNativeInstance
to be null, and thus require a creation call to execute.  Because this call must
be executed on a main thread we get crashes.

Solution is to always post this action to the main thread as a protection against
background execution of the ReactNativeInstance.createReactNativeInstanceManager call.
.