### PR TITLE
Allow callback from JS on notification handling completion

### DIFF
--- a/lib/dist/adapters/CompletionCallbackWrapper.js
+++ b/lib/dist/adapters/CompletionCallbackWrapper.js
@@ -8,21 +8,27 @@ class CompletionCallbackWrapper {
     wrapReceivedBackgroundCallback(callback) {
         return (notification) => {
             if (!this.applicationIsVisible()) {
-                this.wrapReceivedAndInvoke(callback, notification);
+                this.wrapReceivedAndInvoke(callback, notification, true);
             }
         };
     }
     wrapReceivedForegroundCallback(callback) {
         return (notification) => {
             if (this.applicationIsVisible()) {
-                this.wrapReceivedAndInvoke(callback, notification);
+                this.wrapReceivedAndInvoke(callback, notification, false);
             }
         };
     }
-    wrapReceivedAndInvoke(callback, notification) {
+    wrapReceivedAndInvoke(callback, notification, background) {
         const completion = (response) => {
             if (react_native_1.Platform.OS === 'ios') {
-                this.nativeCommandsSender.finishPresentingNotification(notification.identifier, response);
+                const identifier = notification.identifier;
+                if (background) {
+                    this.nativeCommandsSender.finishHandlingBackgroundAction(identifier, response);
+                }
+                else {
+                    this.nativeCommandsSender.finishPresentingNotification(identifier, response);
+                }
             }
         };
         callback(notification, completion);

--- a/lib/dist/adapters/NativeCommandsSender.d.ts
+++ b/lib/dist/adapters/NativeCommandsSender.d.ts
@@ -23,4 +23,5 @@ export declare class NativeCommandsSender {
     getDeliveredNotifications(): Promise<Notification[]>;
     finishPresentingNotification(notificationId: string, notificationCompletion: NotificationCompletion): void;
     finishHandlingAction(notificationId: string): void;
+    finishHandlingBackgroundAction(notificationId: string, backgroundFetchResult: string): void;
 }

--- a/lib/dist/adapters/NativeCommandsSender.js
+++ b/lib/dist/adapters/NativeCommandsSender.js
@@ -59,5 +59,8 @@ class NativeCommandsSender {
     finishHandlingAction(notificationId) {
         this.nativeCommandsModule.finishHandlingAction(notificationId);
     }
+    finishHandlingBackgroundAction(notificationId, backgroundFetchResult) {
+        this.nativeCommandsModule.finishHandlingBackgroundAction(notificationId, backgroundFetchResult);
+    }
 }
 exports.NativeCommandsSender = NativeCommandsSender;

--- a/lib/dist/events/EventsRegistry.d.ts
+++ b/lib/dist/events/EventsRegistry.d.ts
@@ -11,7 +11,7 @@ export declare class EventsRegistry {
     constructor(nativeEventsReceiver: NativeEventsReceiver, completionCallbackWrapper: CompletionCallbackWrapper);
     registerRemoteNotificationsRegistered(callback: (event: Registered) => void): EmitterSubscription;
     registerNotificationReceivedForeground(callback: (notification: Notification, completion: (response: NotificationCompletion) => void) => void): EmitterSubscription;
-    registerNotificationReceivedBackground(callback: (notification: Notification, completion: (response: NotificationCompletion) => void) => void): EmitterSubscription;
+    registerNotificationReceivedBackground(callback: (notification: Notification, completion: (response: string) => void) => void): EmitterSubscription;
     registerNotificationOpened(callback: (notification: Notification, completion: () => void, action?: NotificationActionResponse) => void): EmitterSubscription;
     registerRemoteNotificationsRegistrationFailed(callback: (event: RegistrationError) => void): EmitterSubscription;
 }

--- a/lib/dist/events/EventsRegistry.test.js
+++ b/lib/dist/events/EventsRegistry.test.js
@@ -93,7 +93,7 @@ describe('EventsRegistry', () => {
         });
         it('should invoke finishPresentingNotification', () => {
             const notification = new Notification_1.Notification({ identifier: 'notificationId' });
-            const response = { alert: true };
+            const response = 'none';
             uut.registerNotificationReceivedBackground((notification, completion) => {
                 completion(response);
                 expect(mockNativeCommandsSender.finishPresentingNotification).toBeCalledWith(notification.identifier, response);
@@ -104,7 +104,7 @@ describe('EventsRegistry', () => {
         it('should not invoke finishPresentingNotification on Android', () => {
             react_native_1.Platform.OS = 'android';
             const expectedNotification = new Notification_1.Notification({ identifier: 'notificationId' });
-            const response = { alert: true };
+            const response = 'none';
             uut.registerNotificationReceivedBackground((notification, completion) => {
                 completion(response);
                 expect(expectedNotification).toEqual(notification);

--- a/lib/ios/RCTConvert+RNNotifications.h
+++ b/lib/ios/RCTConvert+RNNotifications.h
@@ -21,6 +21,10 @@
 + (UNNotificationPresentationOptions)UNNotificationPresentationOptions:(id)json;
 @end
 
+@interface RCTConvert (UIBackgroundFetchResult)
++ (UIBackgroundFetchResult)UIBackgroundFetchResult:(NSString *)result;
+@end
+
 @interface RCTConvert (NSDictionary)
-+ (NSDictionary *)NotificationUserInfo:(NSDictionary *)userInfo;
++ (NSDictionary *)NotificationUserInfo:(NSDictionary *)userInfo withIdentifier:(NSString *)identifier;
 @end

--- a/lib/ios/RCTConvert+RNNotifications.m
+++ b/lib/ios/RCTConvert+RNNotifications.m
@@ -118,8 +118,9 @@
 @end
 
 @implementation RCTConvert (NSDictionary)
-+ (NSDictionary *)NotificationUserInfo:(NSDictionary *)userInfo {
++ (NSDictionary *)NotificationUserInfo:(NSDictionary *)userInfo withIdentifier:(NSString *)identifier {
     NSMutableDictionary *formattedNotification = [NSMutableDictionary dictionary];
+    formattedNotification[@"identifier"] = identifier;
     [formattedNotification addEntriesFromDictionary:[NSDictionary dictionaryWithDictionary:RCTNullIfNil(RCTJSONClean(userInfo))]];
     return formattedNotification;
 }
@@ -140,6 +141,20 @@
     }
     
     return options;
+}
+
+@end
+
+@implementation RCTConvert (UIBackgroundFetchResult)
+
++ (UIBackgroundFetchResult)UIBackgroundFetchResult:(NSString *)backgroundFetchResult {
+    UIBackgroundFetchResult result = UIBackgroundFetchResultNoData;
+    if ([@"newData" isEqualToString:backgroundFetchResult]) {
+        result = UIBackgroundFetchResultNewData;
+    } else if ([@"failed" isEqualToString:backgroundFetchResult]) {
+        result = UIBackgroundFetchResultFailed;
+    }
+    return result;
 }
 
 @end

--- a/lib/ios/RNBridgeModule.m
+++ b/lib/ios/RNBridgeModule.m
@@ -26,7 +26,7 @@ RCT_EXPORT_MODULE();
 - (void)setBridge:(RCTBridge *)bridge {
     _bridge = bridge;
     if ([_bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey]) {
-        [[RNNotificationsStore sharedInstance] setInitialNotification:[_bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey] fetchCompletionHandler:nil];
+        [[RNNotificationsStore sharedInstance] setInitialNotification:[_bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey] withFetchCompletionHandler:nil];
     }
 }
 
@@ -50,6 +50,10 @@ RCT_EXPORT_METHOD(finishHandlingAction:(NSString *)completionKey) {
 
 RCT_EXPORT_METHOD(finishPresentingNotification:(NSString *)completionKey presentingOptions:(NSDictionary *)presentingOptions) {
     [_commandsHandler finishPresentingNotification:completionKey presentingOptions:presentingOptions];
+}
+
+RCT_EXPORT_METHOD(finishHandlingBackgroundAction:(NSString *)completionKey backgroundFetchResult:(NSString *)backgroundFetchResult) {
+    [_commandsHandler finishHandlingBackgroundAction:completionKey backgroundFetchResult:backgroundFetchResult];
 }
 
 RCT_EXPORT_METHOD(abandonPermissions) {

--- a/lib/ios/RNBridgeModule.m
+++ b/lib/ios/RNBridgeModule.m
@@ -26,7 +26,7 @@ RCT_EXPORT_MODULE();
 - (void)setBridge:(RCTBridge *)bridge {
     _bridge = bridge;
     if ([_bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey]) {
-        [[RNNotificationsStore sharedInstance] setInitialNotification:[_bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey]];
+        [[RNNotificationsStore sharedInstance] setInitialNotification:[_bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey] fetchCompletionHandler:nil];
     }
 }
 

--- a/lib/ios/RNCommandsHandler.h
+++ b/lib/ios/RNCommandsHandler.h
@@ -15,6 +15,8 @@
 
 - (void)finishPresentingNotification:(NSString *)completionKey presentingOptions:(NSDictionary *)presentingOptions;
 
+- (void)finishHandlingBackgroundAction:(NSString *)completionKey backgroundFetchResult:(NSString *)backgroundFetchResult;
+
 - (void)abandonPermissions;
 
 - (void)registerPushKit;

--- a/lib/ios/RNCommandsHandler.m
+++ b/lib/ios/RNCommandsHandler.m
@@ -33,6 +33,10 @@
     [[RNNotificationsStore sharedInstance] completePresentation:completionKey withPresentationOptions:[RCTConvert UNNotificationPresentationOptions:presentingOptions]];
 }
 
+- (void)finishHandlingBackgroundAction:(NSString *)completionKey backgroundFetchResult:(NSString *)backgroundFetchResult {
+    [[RNNotificationsStore sharedInstance] completeBackgroundAction:completionKey withBackgroundFetchResult:[RCTConvert UIBackgroundFetchResult:backgroundFetchResult]];
+}
+
 - (void)abandonPermissions {
     [[UIApplication sharedApplication] unregisterForRemoteNotifications];
 }

--- a/lib/ios/RNCommandsHandler.m
+++ b/lib/ios/RNCommandsHandler.m
@@ -22,7 +22,7 @@
 }
 
 - (void)getInitialNotification:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
-    resolve([[RNNotificationsStore sharedInstance] initialNotification]);
+    resolve([[RNNotificationsStore sharedInstance] getInitialNotification]);
 }
 
 - (void)finishHandlingAction:(NSString *)completionKey {

--- a/lib/ios/RNEventEmitter.h
+++ b/lib/ios/RNEventEmitter.h
@@ -4,6 +4,7 @@ static NSString* const RNRegistered                  = @"remoteNotificationsRegi
 static NSString* const RNRegistrationFailed          = @"remoteNotificationsRegistrationFailed";
 static NSString* const RNPushKitRegistered           = @"pushKitRegistered";
 static NSString* const RNNotificationReceived        = @"notificationReceived";
+static NSString* const RNNotificationReceivedBackground = @"notificationReceivedBackground";
 static NSString* const RNNotificationOpened          = @"notificationOpened";
 static NSString* const RNPushKitNotificationReceived = @"pushKitNotificationReceived";
 

--- a/lib/ios/RNEventEmitter.m
+++ b/lib/ios/RNEventEmitter.m
@@ -9,6 +9,7 @@ RCT_EXPORT_MODULE();
              RNRegistrationFailed,
              RNPushKitRegistered,
              RNNotificationReceived,
+             RNNotificationReceivedBackground,
              RNNotificationOpened,
              RNPushKitNotificationReceived];
 }

--- a/lib/ios/RNNotificationEventHandler.h
+++ b/lib/ios/RNNotificationEventHandler.h
@@ -12,6 +12,6 @@
 
 - (void)didReceiveForegroundNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler;
 - (void)didReceiveNotificationResponse:(UNNotificationResponse *)notificationResponse completionHandler:(void (^)(void))completionHandler;
-- (void)didReceiveSilentNotification:(NSDictionary *)userInfo;
+- (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 
 @end

--- a/lib/ios/RNNotificationEventHandler.m
+++ b/lib/ios/RNNotificationEventHandler.m
@@ -33,8 +33,10 @@
     [RNEventEmitter sendEvent:RNNotificationOpened body:[RNNotificationParser parseNotificationResponse:response]];
 }
 
-- (void)didReceiveSilentNotification:(NSDictionary *)userInfo {
-    [RNEventEmitter sendEvent:RNNotificationReceived body:[RNNotificationParser parseNotificationUserInfo:userInfo]];
+- (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    NSString *uuid = [[NSUUID UUID] UUIDString];
+    [_store setBackgroundActionCompletionHandler:completionHandler withCompletionKey:uuid];
+    [RNEventEmitter sendEvent:RNNotificationReceivedBackground body:[RNNotificationParser parseNotificationUserInfo:userInfo withIdentifier:uuid]];
 }
 
 @end

--- a/lib/ios/RNNotificationParser.h
+++ b/lib/ios/RNNotificationParser.h
@@ -5,6 +5,6 @@
 
 + (NSDictionary *)parseNotificationResponse:(UNNotificationResponse *)response;
 + (NSDictionary *)parseNotification:(UNNotification *)notification;
-+ (NSDictionary *)parseNotificationUserInfo:(NSDictionary *)userInfo;
++ (NSDictionary *)parseNotificationUserInfo:(NSDictionary *)userInfo withIdentifier:(NSString *)identifier;
 
 @end

--- a/lib/ios/RNNotificationParser.m
+++ b/lib/ios/RNNotificationParser.m
@@ -7,8 +7,8 @@
     return [RCTConvert UNNotificationPayload:notification];
 }
 
-+ (NSDictionary *)parseNotificationUserInfo:(NSDictionary *)userInfo {
-    return [RCTConvert NotificationUserInfo:userInfo];
++ (NSDictionary *)parseNotificationUserInfo:(NSDictionary *)userInfo withIdentifier:(NSString *)identifier {
+    return [RCTConvert NotificationUserInfo:userInfo withIdentifier:(NSString *)identifier];
 }
 
 + (NSDictionary *)parseNotificationResponse:(UNNotificationResponse *)response {

--- a/lib/ios/RNNotifications.h
+++ b/lib/ios/RNNotifications.h
@@ -9,7 +9,7 @@
 + (void)startMonitorNotifications;
 + (void)startMonitorPushKitNotifications;
 
-+ (void)didReceiveSilentNotification:(NSDictionary *)userInfo;
++ (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken;
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;

--- a/lib/ios/RNNotifications.m
+++ b/lib/ios/RNNotifications.m
@@ -39,8 +39,8 @@
     [[self sharedInstance] startMonitorPushKitNotifications];
 }
 
-+ (void)didReceiveSilentNotification:(NSDictionary *)userInfo {
-    [[self sharedInstance] didReceiveSilentNotification:userInfo];
++ (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    [[self sharedInstance] didReceiveBackgroundNotification:userInfo withCompletionHandler:completionHandler];
 }
 
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken {
@@ -73,8 +73,8 @@
     _pushKit = [[RNPushKit alloc] initWithEventHandler:_pushKitEventHandler];
 }
 
-- (void)didReceiveSilentNotification:(NSDictionary *)userInfo {
-    [_notificationEventHandler didReceiveSilentNotification:userInfo];
+- (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    [_notificationEventHandler didReceiveBackgroundNotification:userInfo withCompletionHandler:completionHandler];
 }
 
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken {

--- a/lib/ios/RNNotificationsStore.h
+++ b/lib/ios/RNNotificationsStore.h
@@ -5,7 +5,7 @@ typedef void (^SimpleBlock)();
 
 @interface RNNotificationsStore : NSObject
 
-@property (nonatomic, assign) BOOL jsIsReady;
+@property (nonatomic, assign) BOOL hasInitialNotificationBeenFetched;
 
 + (instancetype)sharedInstance;
 

--- a/lib/ios/RNNotificationsStore.h
+++ b/lib/ios/RNNotificationsStore.h
@@ -1,8 +1,6 @@
 #import <Foundation/Foundation.h>
 @import UserNotifications;
 
-typedef void (^SimpleBlock)();
-
 @interface RNNotificationsStore : NSObject
 
 @property (nonatomic, assign) BOOL hasInitialNotificationBeenFetched;
@@ -11,9 +9,11 @@ typedef void (^SimpleBlock)();
 
 - (void)completeAction:(NSString *)completionKey;
 - (void)completePresentation:(NSString *)completionKey withPresentationOptions:(UNNotificationPresentationOptions)presentationOptions;
+- (void)completeBackgroundAction:(NSString *)completionKey withBackgroundFetchResult:(UIBackgroundFetchResult)backgroundFetchResult;
 - (void)setActionCompletionHandler:(void (^)(void))completionHandler withCompletionKey:(NSString *)completionKey;
 - (void)setPresentationCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler withCompletionKey:(NSString *)completionKey;
-- (void)setInitialNotification:(NSDictionary *)initialNotification fetchCompletionHandler:(SimpleBlock)fetchCompletionHandler;
+- (void)setBackgroundActionCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler withCompletionKey:(NSString *)completionKey;
+- (void)setInitialNotification:(NSDictionary *)initialNotification withFetchCompletionHandler:(void (^)(UIBackgroundFetchResult))fetchCompletionHandler;
 
 - (NSDictionary *)getInitialNotification;
 - (void (^)(void))getActionCompletionHandler:(NSString *)key;

--- a/lib/ios/RNNotificationsStore.h
+++ b/lib/ios/RNNotificationsStore.h
@@ -1,9 +1,11 @@
 #import <Foundation/Foundation.h>
 @import UserNotifications;
 
+typedef void (^SimpleBlock)();
+
 @interface RNNotificationsStore : NSObject
 
-@property (nonatomic, retain) NSDictionary* initialNotification;
+@property (nonatomic, assign) BOOL jsIsReady;
 
 + (instancetype)sharedInstance;
 
@@ -11,7 +13,9 @@
 - (void)completePresentation:(NSString *)completionKey withPresentationOptions:(UNNotificationPresentationOptions)presentationOptions;
 - (void)setActionCompletionHandler:(void (^)(void))completionHandler withCompletionKey:(NSString *)completionKey;
 - (void)setPresentationCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler withCompletionKey:(NSString *)completionKey;
+- (void)setInitialNotification:(NSDictionary *)initialNotification fetchCompletionHandler:(SimpleBlock)fetchCompletionHandler;
 
+- (NSDictionary *)getInitialNotification;
 - (void (^)(void))getActionCompletionHandler:(NSString *)key;
 - (void (^)(UNNotificationPresentationOptions))getPresentationCompletionHandler:(NSString *)key;
 

--- a/lib/ios/RNNotificationsStore.m
+++ b/lib/ios/RNNotificationsStore.m
@@ -1,5 +1,12 @@
 #import "RNNotificationsStore.h"
 
+@interface RNNotificationsStore()
+
+@property (nonatomic, retain) NSDictionary* initialNotification;
+@property (nonatomic, copy) SimpleBlock initialNotificationFetchCompletionHandler;
+
+@end
+
 @implementation RNNotificationsStore
 NSMutableDictionary* _actionCompletionHandlers;
 NSMutableDictionary* _presentationCompletionHandlers;
@@ -27,6 +34,25 @@ NSMutableDictionary* _presentationCompletionHandlers;
 
 - (void)setPresentationCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler withCompletionKey:(NSString *)completionKey {
     _presentationCompletionHandlers[completionKey] = completionHandler;
+}
+
+- (void)setInitialNotification:(NSDictionary *)initialNotification fetchCompletionHandler:(SimpleBlock)fetchCompletionHandler {
+    self.initialNotification = initialNotification;
+    self.initialNotificationFetchCompletionHandler = fetchCompletionHandler;
+}
+
+- (NSDictionary *)getInitialNotification {
+    self.jsIsReady = YES;
+
+    if (self.initialNotification && self.initialNotificationFetchCompletionHandler) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.initialNotificationFetchCompletionHandler();
+        });
+    }
+
+    NSDictionary *initialNotification = self.initialNotification;
+    self.initialNotification = nil;
+    return initialNotification;
 }
 
 - (void (^)(void))getActionCompletionHandler:(NSString *)key {

--- a/lib/ios/RNNotificationsStore.m
+++ b/lib/ios/RNNotificationsStore.m
@@ -42,7 +42,7 @@ NSMutableDictionary* _presentationCompletionHandlers;
 }
 
 - (NSDictionary *)getInitialNotification {
-    self.jsIsReady = YES;
+    self.hasInitialNotificationBeenFetched = YES;
 
     if (self.initialNotification && self.initialNotificationFetchCompletionHandler) {
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/lib/src/adapters/CompletionCallbackWrapper.ts
+++ b/lib/src/adapters/CompletionCallbackWrapper.ts
@@ -13,7 +13,7 @@ export class CompletionCallbackWrapper {
   public wrapReceivedBackgroundCallback(callback: Function): (notification: Notification) => void {
     return (notification) => {
       if (!this.applicationIsVisible()) {
-        this.wrapReceivedAndInvoke(callback, notification);
+        this.wrapReceivedAndInvoke(callback, notification, true);
       }
     }
   }
@@ -21,15 +21,20 @@ export class CompletionCallbackWrapper {
   public wrapReceivedForegroundCallback(callback: Function): (notification: Notification) => void {
     return (notification) => {
       if (this.applicationIsVisible()) {
-        this.wrapReceivedAndInvoke(callback, notification);
+        this.wrapReceivedAndInvoke(callback, notification, false);
       }
     }
   }
 
-  private wrapReceivedAndInvoke(callback: Function, notification: Notification) {
-    const completion = (response: NotificationCompletion) => {
+  private wrapReceivedAndInvoke(callback: Function, notification: Notification, background: boolean) {
+    const completion = (response: NotificationCompletion | string) => {
       if (Platform.OS === 'ios') {
-        this.nativeCommandsSender.finishPresentingNotification((notification as unknown as NotificationIOS).identifier, response);
+        const identifier = (notification as unknown as NotificationIOS).identifier;
+        if (background) {
+          this.nativeCommandsSender.finishHandlingBackgroundAction(identifier, response as string);
+        } else {
+          this.nativeCommandsSender.finishPresentingNotification(identifier, response as NotificationCompletion);
+        }
       }
     };
 

--- a/lib/src/adapters/NativeCommandsSender.ts
+++ b/lib/src/adapters/NativeCommandsSender.ts
@@ -23,6 +23,7 @@ interface NativeCommandsModule {
   setCategories(categories: [NotificationCategory?]): void;
   finishPresentingNotification(notificationId: string, callback: NotificationCompletion): void;
   finishHandlingAction(notificationId: string): void;
+  finishHandlingBackgroundAction(notificationId: string, backgroundFetchResult: string): void;
 }
 
 export class NativeCommandsSender {
@@ -101,5 +102,9 @@ export class NativeCommandsSender {
 
   finishHandlingAction(notificationId: string): void {
     this.nativeCommandsModule.finishHandlingAction(notificationId);
+  }
+
+  finishHandlingBackgroundAction(notificationId: string, backgroundFetchResult: string): void {
+    this.nativeCommandsModule.finishHandlingBackgroundAction(notificationId, backgroundFetchResult);
   }
 }

--- a/lib/src/events/EventsRegistry.test.ts
+++ b/lib/src/events/EventsRegistry.test.ts
@@ -119,7 +119,7 @@ describe('EventsRegistry', () => {
 
     it('should invoke finishPresentingNotification', () => {
       const notification: Notification  = new Notification({identifier: 'notificationId'});
-      const response: NotificationCompletion  = {alert: true}
+      const response = 'none';
       
       uut.registerNotificationReceivedBackground((notification, completion) => {
         completion(response);
@@ -133,7 +133,7 @@ describe('EventsRegistry', () => {
     it('should not invoke finishPresentingNotification on Android', () => {
       Platform.OS = 'android';
       const expectedNotification: Notification  = new Notification({identifier: 'notificationId'});
-      const response: NotificationCompletion  = {alert: true}
+      const response = 'none';
       
       uut.registerNotificationReceivedBackground((notification, completion) => {
         completion(response);

--- a/lib/src/events/EventsRegistry.ts
+++ b/lib/src/events/EventsRegistry.ts
@@ -23,7 +23,7 @@ export class EventsRegistry {
     return this.nativeEventsReceiver.registerNotificationReceived(this.completionCallbackWrapper.wrapReceivedForegroundCallback(callback));
   }
 
-  public registerNotificationReceivedBackground(callback: (notification: Notification, completion: (response: NotificationCompletion) => void) => void): EmitterSubscription {
+  public registerNotificationReceivedBackground(callback: (notification: Notification, completion: (response: string) => void) => void): EmitterSubscription {
     return this.nativeEventsReceiver.registerNotificationReceived(this.completionCallbackWrapper.wrapReceivedBackgroundCallback(callback));
   }
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-notifications",
-  "version": "3.1.2-patch.1",
+  "version": "3.1.2-patch.2",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-notifications",
-  "version": "3.1.2-patch.2",
+  "version": "3.1.2-patch.3",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
App should call getInitialNotification() upon boot complete, so we can treat that moment as when js is ready.

For `application:didReceiveRemoteNotification:fetchCompletionHandler:`, it will be something like this:
```objective-c
  if ([RNNotificationsStore sharedInstance].jsIsReady) {
    [RNNotifications didReceiveSilentNotification:userInfo];
    completionHandler(UIBackgroundFetchResultNoData);
  } else {
    [[RNNotificationsStore sharedInstance] setInitialNotification:userInfo fetchCompletionHandler:^{
      completionHandler(UIBackgroundFetchResultNoData);
    }];
  }
```